### PR TITLE
Set initial options property value to empty array, not object.

### DIFF
--- a/runway/model.py
+++ b/runway/model.py
@@ -15,7 +15,7 @@ from .utils import gzipped, serialize_command, cast_to_obj
 
 class RunwayModel(object):
     def __init__(self):
-        self.options = {}
+        self.options = []
         self.setup_fn = None
         self.commands = {}
         self.command_fns = {}


### PR DESCRIPTION
It looks like `RunwayModel.options` never had its default value changed from a dictionary during the options overhaul last month. This *should* be a non-breaking change, but @agermanidis you might want to confirm that.