### PR TITLE
Add JS HTTP->HTTPS redirect

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -1,0 +1,6 @@
+// Read the Docs doesn't currently support HTTPS redirects for CNAME domains
+// This is a hacky work around that keeps us free of having to host our own
+// server-side component.
+if (location.protocol != 'https:') {
+ location.href = 'https:' + window.location.href.substring(window.location.protocol.length);
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,3 +102,4 @@ def setup(app):
     }, True)
     app.add_transform(AutoStructify)
     app.add_stylesheet('css/custom.css')
+    app.add_javascript('js/custom.js')


### PR DESCRIPTION
Read the docs does not currently support HTTP -> HTTPS redirects for custom domains (CNAME), but they are actively working on it: https://github.com/rtfd/readthedocs.org/issues/4641

Until those changes are merged we'll have to handle the redirection for the docs ourselves. This is a  quick and dirty JS redirect that keeps us from having to host any server-side things ourselves. This can be a temporary solution until proper 302 redirects are implemented in RtD.