### PR TITLE
Replace InvalidInputError with InvalidArgumentError

### DIFF
--- a/runway/data_types.py
+++ b/runway/data_types.py
@@ -10,7 +10,7 @@ else:
 import numpy as np
 from PIL import Image
 from .utils import is_url, download_to_temp_dir, try_cast_np_scalar
-from .exceptions import MissingArgumentError, InvalidInputError
+from .exceptions import MissingArgumentError, InvalidArgumentError
 
 
 class any(object):
@@ -255,19 +255,25 @@ class category(object):
         :type choices: A list of strings
         :param default: A default list of categories, defaults to None
         :type default: A list of strings
-        :raises MissingArgumentError: A missing argument error if choices is \
+        :raises MissingArgumentError: A missing argument error if choices is
             not a list with at least one element.
+        :raises InvalidArgumentError: An invalid argument error if a default
+            argument is specified and that argument does not appear in the
+            choices list.
     """
 
     def __init__(self, name=None, choices=None, default=None):
         if choices is None or len(choices) == 0: raise MissingArgumentError('choices')
+        if default is not None and default not in choices:
+            msg = 'default argument {} is not in choices list'.format(default)
+            raise InvalidArgumentError(msg)
         self.name = name or 'category'
         self.choices = choices
         self.default = default or self.choices[0]
 
     def deserialize(self, value):
         if value not in self.choices:
-            raise InvalidInputError(self.name)
+            raise InvalidArgumentError(self.name)
         return value
 
     def serialize(self, value):

--- a/runway/exceptions.py
+++ b/runway/exceptions.py
@@ -74,19 +74,20 @@ class MissingInputError(RunwayError):
         self.code = 400
 
 
-class InvalidInputError(RunwayError):
-    """An error indicating that an input received by ``@runway.command()`` is
-    invalid, given its data type.
+class InvalidArgumentError(RunwayError):
+    """An error indicating that an argument is invalid.
+    May be raised by ``@runway.setup()`` or ``@runway.command()`` decorated
+    functions if they receive a bad input value.
 
-    :ivar message: An error message, set to "Invalid input:
+    :ivar message: An error message, set to "Invalid argument:
         {NAME_OF_MISSING_OPTION}"
     :type message: string
     :ivar code: An HTTP error code, set to 400
     :type code: number
     """
     def __init__(self, name):
-        super(InvalidInputError, self).__init__()
-        self.message = 'Invalid input: %s.' % name
+        super(InvalidArgumentError, self).__init__()
+        self.message = 'Invalid argument: %s.' % name
         self.code = 400
 
 

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -143,6 +143,10 @@ def test_category_choices_empty_arr():
     with pytest.raises(MissingArgumentError):
         cat = category(choices=[])
 
+def test_category_default_not_in_choices():
+    with pytest.raises(InvalidArgumentError):
+        cat = category(choices=['one', 'two'], default='three')
+
 def test_category_default_choice():
     cat = category(choices=['one', 'two', 'three'], default='two')
     assert cat.default == 'two'
@@ -153,5 +157,5 @@ def test_category_default_choice_is_first_if_not_specified():
 
 def test_category_deserialized_value_is_not_in_choices():
     cat = category(choices=['one', 'two', 'three'])
-    with pytest.raises(InvalidInputError):
+    with pytest.raises(InvalidArgumentError):
         cat.deserialize('four')

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -59,9 +59,9 @@ def test_missing_input_error():
     expect = 'Missing input: test_option.'
     check_code_and_error(MissingInputError, 400, expect, inpt='test_option')
 
-def test_invalid_input_error():
-    expect = 'Invalid input: test_option.'
-    check_code_and_error(InvalidInputError, 400, expect, inpt='test_option')
+def test_invalid_argument_error():
+    expect = 'Invalid argument: test_option.'
+    check_code_and_error(InvalidArgumentError, 400, expect, inpt='test_option')
 
 def test_inference_error():
     expect = 'Error during inference: test_option.'


### PR DESCRIPTION
Replace `InvalidInputError` with more general `InvalidArgumentError`. This error can be thrown liberally in the SDK whenever an argument is of the wrong type, but can also be returned to the user over the network if they are interfacing with the model incorrectly.