### PR TITLE
Remove use of InvalidInputError in image() and image tests

### DIFF
--- a/runway/data_types.py
+++ b/runway/data_types.py
@@ -166,7 +166,7 @@ class image(object):
         elif issubclass(type(value), Image.Image):
             im_pil = value
         else:
-            raise InvalidInputError('value is not a PIL or numpy image')
+            raise InvalidArgumentError('value is not a PIL or numpy image')
         buffer = IO()
         im_pil.save(buffer, format='JPEG')
         return 'data:image/jpeg;base64,' + base64.b64encode(buffer.getvalue()).decode('utf8')

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -311,11 +311,11 @@ def test_image_serialize_and_deserialize():
     assert issubclass(type(deserialize_np_img), Image.Image)
 
 def test_image_serialize_invalid_type():
-    with pytest.raises(InvalidInputError):
+    with pytest.raises(InvalidArgumentError):
         image().serialize(True)
 
-    with pytest.raises(InvalidInputError):
+    with pytest.raises(InvalidArgumentError):
         image().serialize([])
 
-    with pytest.raises(InvalidInputError):
+    with pytest.raises(InvalidArgumentError):
         image().serialize('data:image/jpeg;base64,')


### PR DESCRIPTION
The switch from `InvalidInputError` to `InvalidArgumentError` never made it into my `more-tests` branch, so that caused the `master` build pipeline to fail. This should fix that :) Glad our tests caught this!