### PR TITLE
Add docs build step to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,11 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             make dev
+      - run:
+          name: install python dependencies for docs
+          command: |
+            . venv/bin/activate
+            make dev-docs
       - save_cache:
           key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-docs.txt" }}
           paths:
@@ -48,6 +53,11 @@ jobs:
           command: |
             . venv/bin/activate
             bash <(curl -s https://codecov.io/bash)
+      - run:
+          name: build docs
+          command: |
+            . venv/bin/activate
+            make docs
   build-py27:
     docker:
       - image: continuumio/miniconda:latest
@@ -62,7 +72,7 @@ jobs:
           name: install make
           command: |
             apt-get update
-            apt-get install -y build-essential            
+            apt-get install -y build-essential
       - restore_cache:
           key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
       - run:


### PR DESCRIPTION
Docs will be built (for test purposes only, not deployed) during the Python 3.6 Circle CI Job.