### PR TITLE
Add modelSDKVersion to manifest at GET /

### DIFF
--- a/runway/model.py
+++ b/runway/model.py
@@ -12,6 +12,7 @@ from .exceptions import RunwayError, MissingInputError, MissingOptionError, \
     InferenceError, UnknownCommandError, SetupError
 from .data_types import *
 from .utils import gzipped, serialize_command, cast_to_obj
+from .__version__ import __version__ as modelSDKVersion
 
 class RunwayModel(object):
     """A Runway Model server. A singleton instance of this class is created automatically
@@ -33,6 +34,7 @@ class RunwayModel(object):
         @self.app.route('/')
         def manifest():
             return json.dumps(dict(
+                modelSDKVersion=modelSDKVersion,
                 options=[opt.to_dict() for opt in self.options],
                 commands=[serialize_command(cmd) for cmd in self.commands.values()]
             ))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,6 +8,7 @@ import os
 import json
 import pytest
 from runway.model import RunwayModel
+from runway.__version__ import __version__ as modelSDKVersion
 from runway.data_types import category, text, number, array, image, vector, file, any as any_type
 from runway.exceptions import *
 from utils import get_test_client
@@ -23,6 +24,7 @@ def test_model_setup_and_command():
     closure = dict(setup_ran = False, command_ran = False)
 
     expected_manifest = {
+        'modelSDKVersion': modelSDKVersion,
         'options': [{
             'type': 'category',
             'name': 'size',


### PR DESCRIPTION
I added the model version inside of the manifest dictionary itself, but we could move this outside and store the current manifest in a `manifest` key or something if we wanted to. I went with the non-breaking-change approach.

Also thinking of other possibly useful keys in a meta object... perhaps:
* `GPU` indicating the model is running in an environment with `GPU=1`.
* `millisRunning` indicating the number of milliseconds the model has been running via `runway.run()`.

Those were some metadatas that came to mind right off the start, but I also don't want to over-complicate things. Maybe we should only add what we know we'll need. What do you think @agermanidis?