### PR TITLE
Better JSON handling in requests and responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.0.70
 
+- Model server now wraps common server error codes in JSON responses (e.g. 401, 403, 404, 405, 500).
+- Model server now sniffs the body of `POST` for JSON even if `content-type: application/json` is not sent in the request header. [#1](https://github.com/runwayml/model-sdk/issues/1)
+- Model server now returns `content-type: application/json`. [#6](https://github.com/runwayml/model-sdk/issues/6)
 - Add `RW_NO_SERVE` environment variable and `no_serve` keyword argument to `runway.run()`. These settings prevent `runway.run()` from starting the Flask server so that mock HTTP requests can be made via `app.test_client()`. See [Testing Flask Applications](http://flask.pocoo.org/docs/1.0/testing/) for more details.
 - Add model tests in [`tests/test_model.py`](tests/test_model.py)
 - Minor change to `docs/` so that JavaScript HTTP -> HTTPS redirect only occurs when the protocol is actually `http:`.

--- a/runway/model.py
+++ b/runway/model.py
@@ -121,7 +121,7 @@ class RunwayModel(object):
                 for out in outputs:
                     name = out.to_dict()['name']
                     serialized_outputs[name] = out.serialize(results[name])
-                return jsonify(json.loads(json.dumps(serialized_outputs).encode('utf8')))
+                return jsonify(serialized_outputs)
 
             except RunwayError as err:
                 err.print_exception()

--- a/runway/utils.py
+++ b/runway/utils.py
@@ -12,7 +12,7 @@ if sys.version_info[0] < 3:
 else:
     from io import BytesIO as IO
 import numpy as np
-from flask import after_this_request, request
+from flask import after_this_request, request, jsonify
 
 
 URL_REGEX = re.compile(
@@ -23,6 +23,19 @@ URL_REGEX = re.compile(
         r'(?::\d+)?' # optional port
         r'(?:/?|[/?]\S+)$', re.IGNORECASE)
 
+def validate_post_request_body_is_json(f):
+    @functools.wraps(f)
+    def wrapped(*args, **kwargs):
+        json = get_json_or_none_if_invalid(request)
+        if json is not None:
+            return f(*args, **kwargs)
+        else:
+            err_msg = 'The body of all POST requests must contain JSON'
+            return jsonify(dict(error=err_msg)), 400
+    return wrapped
+
+def get_json_or_none_if_invalid(request):
+    return request.get_json(force=True, silent=True)
 
 def serialize_command(cmd):
     ret = {}


### PR DESCRIPTION
* Always return `content-type: application/json` as response MIME type
* Sniff body in POST requests for JSON even if `content-type: application/json` is not specified. If the sniff is successful, allow the request. If it fails return a nicer 400 explaining the body must be JSON instead of a 500 internal server error.
* Return JSON for common server errors (401, 403, 404, 405, and 500).

My hope is that this gets us into the territory where the model server now *only* speaks JSON as responses. I have yet to get an `html/text` since implementing these changes but we should be on the lookout in case we missed something.

Closes #1 
Closes #6 
