### PR TITLE
Better error message when user submits an invalid category choice.

### DIFF
--- a/runway/data_types.py
+++ b/runway/data_types.py
@@ -284,7 +284,8 @@ class category(object):
 
     def deserialize(self, value):
         if value not in self.choices:
-            raise InvalidArgumentError(self.name)
+            msg = 'category value "%s" does not appear in choices list.' % value
+            raise InvalidArgumentError(self.name, msg)
         return value
 
     def serialize(self, value):

--- a/runway/exceptions.py
+++ b/runway/exceptions.py
@@ -85,9 +85,10 @@ class InvalidArgumentError(RunwayError):
     :ivar code: An HTTP error code, set to 400
     :type code: number
     """
-    def __init__(self, name):
+    def __init__(self, name, message=None):
         super(InvalidArgumentError, self).__init__()
         self.message = 'Invalid argument: %s.' % name
+        if message is not None: self.message += ' %s' % message
         self.code = 400
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -144,6 +144,50 @@ def test_model_options_missing():
         with pytest.raises(MissingOptionError):
             rw.run(debug=True)
 
+def test_setup_invalid_category():
+
+    rw = RunwayModel()
+    @rw.setup(options={'category': category(choices=['Starks', 'Lannisters'])})
+    def setup(opts):
+        pass
+
+    rw.run(debug=True)
+
+    client = get_test_client(rw)
+    response = client.post('/setup', json={ 'category': 'Tyrells' })
+
+    assert response.status_code == 400
+    json_response = json.loads(response.data)
+    assert 'error' in json_response
+    # ensure the user is displayed an error that indicates the category option
+    # is problematic
+    assert 'Invalid argument: category' in json_response['error']
+    # ensure the user is displayed an error that indicates the problematic value
+    assert 'Tyrells' in json_response['error']
+
+def test_command_invalid_category():
+
+    rw = RunwayModel()
+    inputs = {'category': category(choices=['Starks', 'Lannisters'])}
+    outputs = {'reflect': text }
+    @rw.command('test_command', inputs=inputs, outputs=outputs)
+    def test_command(opts):
+        return opts['category']
+
+    rw.run(debug=True)
+
+    client = get_test_client(rw)
+    response = client.post('/test_command', json={ 'category': 'Targaryen' })
+
+    assert response.status_code == 400
+    json_response = json.loads(response.data)
+    assert 'error' in json_response
+    # ensure the user is displayed an error that indicates the category option
+    # is problematic
+    assert 'Invalid argument: category' in json_response['error']
+    # ensure the user is displayed an error that indicates the problematic value
+    assert 'Targaryen' in json_response['error']
+
 def test_meta(capsys):
 
     rw = RunwayModel()


### PR DESCRIPTION
Closes #5 

Well, actually recent changes cause POSTing an invalid category value return a 400 instead of a 500 like that issue claims, but this is still an improvement as it lets the user know *why* the server didn't like the request.