### PR TITLE
Add description kwargs and BaseType base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Upcoming (CHANGE ME)
+
+- Add `description` keyword argument to all `runway.data_types` and `runway.command()`.
+- Create abstract `runway.data_types.BaseType` class that defines a common interface for all `runway.data_types`.
+
 ## v0.0.73
 
 - Add support for all remote filetypes over HTTP (we are currently only supporting tarballs)

--- a/runway/model.py
+++ b/runway/model.py
@@ -30,6 +30,8 @@ class RunwayModel(object):
         self.model = None
         self.running_status = 'STARTING'
         self.app = Flask(__name__)
+        # support utf-8 in application/json requests and responses
+        self.app.config['JSON_AS_ASCII'] = False
         CORS(self.app)
         self.define_error_handlers()
         self.define_routes()
@@ -212,7 +214,7 @@ class RunwayModel(object):
                 return fn
             return decorator
 
-    def command(self, name, inputs={}, outputs={}):
+    def command(self, name, inputs={}, outputs={}, description=None):
         """This decorator function is used to define the interface for your
         model. All functions that are wrapped by this decorator become exposed
         via HTTP requests to ``/<command_name>``. Each command that you define
@@ -263,6 +265,10 @@ class RunwayModel(object):
             wrapped function as ``runway.data_types``. At least one key value
             pair is required.
         :type outputs: dict
+        :param description: A text description of what this command does.
+            If this parameter is present its value will be rendered as a tooltip
+            in Runway. Defaults to None.
+        :type description: string
         :raises Exception: An exception if there isn't at least one key value
             pair for both inputs and outputs dictionaries
         :return: A decorated function
@@ -285,6 +291,7 @@ class RunwayModel(object):
 
         command_info = dict(
             name=name,
+            description=description,
             inputs=inputs_as_list,
             outputs=outputs_as_list
         )

--- a/runway/model.py
+++ b/runway/model.py
@@ -30,8 +30,13 @@ class RunwayModel(object):
         self.model = None
         self.running_status = 'STARTING'
         self.app = Flask(__name__)
-        # support utf-8 in application/json requests and responses
-        self.app.config['JSON_AS_ASCII'] = False
+        # Support utf-8 in application/json requests and responses.
+        # We wrap this in a try/except block because, for whatever reason,
+        # `make docs` throws a TypeError that keys are unassignable to
+        # self.app.config. This DOES NOT occur when using the RunwayModel module
+        # anywere except in the docs build environment.
+        try: self.app.config['JSON_AS_ASCII'] = False
+        except TypeError: pass
         CORS(self.app)
         self.define_error_handlers()
         self.define_routes()

--- a/runway/utils.py
+++ b/runway/utils.py
@@ -41,6 +41,7 @@ def get_json_or_none_if_invalid(request):
 def serialize_command(cmd):
     ret = {}
     ret['name'] = cmd['name']
+    ret['description'] = cmd['description']
     ret['inputs'] = [inp.to_dict() for inp in cmd['inputs']]
     ret['outputs'] = [inp.to_dict() for inp in cmd['outputs']]
     return ret

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -58,13 +58,15 @@ def test_data_type_interface_file():
 # TEXT -------------------------------------------------------------------------
 def test_text_to_dict():
     default = 'Some default text'
-    txt = text(default=default, min_length=1, max_length=20)
+    description = 'A description about this variable.'
+    txt = text(default=default, description=description, min_length=1, max_length=20)
     obj = txt.to_dict()
     assert obj['type'] == 'text'
     assert obj['name'] == 'text'
     assert obj['default'] == default
     assert obj['minLength'] == 1
     assert obj['maxLength'] == 20
+    assert obj['description'] == description
 
 def test_text_serialization():
     txt = text()
@@ -77,7 +79,8 @@ def test_text_deserialize():
 # NUMBER -----------------------------------------------------------------------
 def test_number_to_dict():
     default = 42
-    num = number(default=default, min=10, max=100)
+    description = 'A description about this variable.'
+    num = number(default=default, description=description, min=10, max=100)
     obj = num.to_dict()
     assert obj['type'] == 'number'
     assert obj['name'] == 'number'
@@ -85,6 +88,7 @@ def test_number_to_dict():
     assert obj['min'] == 10
     assert obj['max'] == 100
     assert obj['step'] == 1
+    assert obj['description'] == description
 
 def test_number_serialization():
     assert 1 == number().serialize(1)
@@ -102,13 +106,15 @@ def test_number_serialize_numpy_scalar():
 
 # ARRAY ------------------------------------------------------------------------
 def test_array_to_dict():
-    arr = array(item_type=text, min_length=5, max_length=10)
+    description = 'A description about this variable.'
+    arr = array(item_type=text, description=description, min_length=5, max_length=10)
     obj = arr.to_dict()
     assert obj['name'] == 'text_array'
     assert obj['type'] == 'array'
     assert obj['itemType'] == text().to_dict()
     assert obj['minLength'] == 5
     assert obj['maxLength'] == 10
+    assert obj['description'] == description
 
 def test_array_no_item_type():
     with pytest.raises(MissingArgumentError):
@@ -135,13 +141,15 @@ def test_array_deserialization():
 
 # VECTOR -----------------------------------------------------------------------
 def test_vector_to_dict():
-    vec = vector(length=128, sampling_mean=0, sampling_std=1)
+    description = 'A description about this variable.'
+    vec = vector(length=128, description=description, sampling_mean=0, sampling_std=1)
     obj = vec.to_dict()
     assert obj['name'] == 'vector'
     assert obj['type'] == 'vector'
     assert obj['length'] == 128
     assert obj['samplingMean'] == 0
     assert obj['samplingStd'] == 1
+    assert obj['description'] == description
 
 def test_vector_no_item_type():
     with pytest.raises(MissingArgumentError):
@@ -173,12 +181,14 @@ def test_vector_default_no_length_arg():
 
 # CATEGORY ---------------------------------------------------------------------
 def test_category_to_dict():
-    cat = category(choices=['one', 'two', 'three'], default='two')
+    description = 'A description about this variable.'
+    cat = category(choices=['one', 'two', 'three'], default='two', description=description)
     obj = cat.to_dict()
     assert obj['name'] == 'category'
     assert obj['type'] == 'category'
     assert obj['oneOf'] == ['one', 'two', 'three']
     assert obj['default'] == 'two'
+    assert obj['description'] == description
 
 def test_category_serialization():
     cat = category(choices=['one', 'two', 'three'], default='two')
@@ -219,13 +229,16 @@ def test_file_to_dict():
     obj = f.to_dict()
     assert obj['name'] == 'file'
     assert obj['type'] == 'file'
+    assert obj['description'] == None
 
 def test_file_to_dict_directory():
-    f = file(is_directory=True)
+    description = 'A description about this variable.'
+    f = file(is_directory=True, description=description)
     obj = f.to_dict()
     assert obj['name'] == 'file'
     assert obj['type'] == 'file'
     assert obj['isDirectory'] == True
+    assert obj['description'] == description
 
 def test_file_serialization_base():
     f = file()
@@ -319,6 +332,7 @@ def test_image_to_dict():
     assert obj['maxWidth'] == 512
     assert obj['minHeight'] == 128
     assert obj['maxHeight'] == 512
+    assert obj['description'] == None
 
 def test_image_serialize_and_deserialize():
     directory = os.path.dirname(os.path.realpath(__file__))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Ensure that the local version of the runway module is used, not a pip
 # installed version
 import sys
@@ -38,7 +39,7 @@ def test_model_setup_and_command():
         }],
         'commands': [{
             'name': 'test_command',
-            'description': 'A test command whose description contains emoji 🕳',
+            'description': None,
             'inputs': [{
                 'type': 'text',
                 'name': 'input',
@@ -65,7 +66,15 @@ def test_model_setup_and_command():
 
     inputs = { 'input': text }
     outputs = { 'output': number }
-    description = 'A test command whose description contains emoji 🕳'
+
+    # Python 2.7 doesn't seem to handle emoji serialization correctly in JSON,
+    # so we will only test emoji serialization/deserialization in Python 3
+    if sys.version_info[0] < 3:
+        description = 'Sorry, Python 2 doesn\'t support emoji very well'
+    else:
+        description = 'A test command whose description contains emoji 🕳'
+    expected_manifest['commands'][0]['description'] = description
+
     @rw.command('test_command', inputs=inputs, outputs=outputs, description=description)
     def test_command(model, opts):
         closure['command_ran'] = True

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -38,6 +38,7 @@ def test_model_setup_and_command():
         }],
         'commands': [{
             'name': 'test_command',
+            'description': 'A test command whose description contains emoji 🕳',
             'inputs': [{
                 'type': 'text',
                 'name': 'input',
@@ -64,7 +65,8 @@ def test_model_setup_and_command():
 
     inputs = { 'input': text }
     outputs = { 'output': number }
-    @rw.command('test_command', inputs=inputs, outputs=outputs)
+    description = 'A test command whose description contains emoji 🕳'
+    @rw.command('test_command', inputs=inputs, outputs=outputs, description=description)
     def test_command(model, opts):
         closure['command_ran'] = True
         return 100
@@ -248,6 +250,7 @@ def test_meta(capsys):
         pass
 
     kwargs_2 = {
+        'description': 'This command is used for testing.',
         'inputs': {
             'any': any_type,
             'file': file
@@ -278,6 +281,7 @@ def test_meta(capsys):
         'commands': [
             {
                 'name': 'command_2',
+                'description': 'This command is used for testing.',
                 'inputs': [
                     {
                         'type': 'any',
@@ -301,6 +305,7 @@ def test_meta(capsys):
             },
             {
                 'name': 'command_1',
+                'description': None,
                 'inputs': [
                     {
                         'channels': 3,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -35,7 +35,8 @@ def test_model_setup_and_command():
             'type': 'category',
             'name': 'size',
             'oneOf': ['big', 'small'],
-            'default': 'big'
+            'default': 'big',
+            'description': 'The size of the model. Bigger is better but also slower.',
         }],
         'commands': [{
             'name': 'test_command',
@@ -43,12 +44,14 @@ def test_model_setup_and_command():
             'inputs': [{
                 'type': 'text',
                 'name': 'input',
+                'description': 'Some input text.',
                 'default': '',
                 'minLength': 0
             }],
             'outputs': [{
                 'type': 'number',
                 'name': 'output',
+                'description': 'An output number.',
                 'default': 0,
                 'min': 0,
                 'max': 1,
@@ -59,13 +62,14 @@ def test_model_setup_and_command():
 
     rw = RunwayModel()
 
-    @rw.setup(options={ 'size': category(choices=['big', 'small']) })
+    description = 'The size of the model. Bigger is better but also slower.'
+    @rw.setup(options={ 'size': category(choices=['big', 'small'], description=description) })
     def setup(opts):
         closure['setup_ran'] = True
         return {}
 
-    inputs = { 'input': text }
-    outputs = { 'output': number }
+    inputs = { 'input': text(description='Some input text.') }
+    outputs = { 'output': number(description='An output number.') }
 
     # Python 2.7 doesn't seem to handle emoji serialization correctly in JSON,
     # so we will only test emoji serialization/deserialization in Python 3
@@ -279,11 +283,13 @@ def test_meta(capsys):
                 'minLength': 0,
                 'type': 'array',
                 'name': 'initialization_array',
+                'description': None,
                 'itemType': {
                     'default': '',
                     'minLength': 0,
                     'type': 'text',
-                    'name': 'text'
+                    'name': 'text',
+                    'description': None
                 }
             }
         ],
@@ -295,10 +301,12 @@ def test_meta(capsys):
                     {
                         'type': 'any',
                         'name': 'any',
+                        'description': None,
                     },
                     {
                         'type': 'file',
                         'name': 'file',
+                        'description': None,
                     },
                 ],
                 'outputs': [
@@ -309,6 +317,7 @@ def test_meta(capsys):
                         'max': 100,
                         'step': 1,
                         'type': 'number',
+                        'description': None
                     },
                 ]
             },
@@ -320,6 +329,7 @@ def test_meta(capsys):
                         'channels': 3,
                         'type': 'image',
                         'name': 'image',
+                        'description': None
                     },
                     {
                         'samplingMean': 0,
@@ -327,7 +337,8 @@ def test_meta(capsys):
                         'type': 'vector',
                         'name': 'vector',
                         'samplingStd': 1,
-                        'default': [0, 0, 0, 0, 0]
+                        'default': [0, 0, 0, 0, 0],
+                        'description': None
                     },
                 ],
                 'outputs': [
@@ -335,7 +346,8 @@ def test_meta(capsys):
                         'default': '',
                         'minLength': 0,
                         'type': 'text',
-                        'name': 'label'
+                        'name': 'label',
+                        'description': None
                     }
                 ]
             }


### PR DESCRIPTION
* Add `description` kwarg to all data types and command functions.
* Add a `BaseType` class that defines a common interface for all data types.

Next up I'll look into removing the `name` argument from the data type constructors themselves.