### PR TITLE
fix(CoC): adding improvements and feeding in incident report link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -56,7 +56,7 @@ No weapons will be allowed at Runway events, community spaces, or in other space
 
 ### 5. Reporting an Incident
 
-If you are at an event and experience any unacceptable please do reach out to Runway staff as soon as possible. We will handle any form of unacceptable behavior as soon as it comes to our attention.
+If you are at an event and experience any unacceptable behavior please do reach out to Runway staff as soon as possible. We will handle any form of unacceptable behavior as soon as it comes to our attention.
 
 If you are subject to or witness unacceptable behavior and want to raise an incident report, please do use our [reporting tool to report the incident](https://docs.google.com/forms/d/e/1FAIpQLSeFaYn-dBkCJ9hRcrCktw1XfqgE8Gf5fu6XnK9FUBIV36iBnQ/viewform) as soon as you can. If you choose to raise an incident report, we will ensure we investigate and provide followup within 2 weeks of the report. Your information will remain confidential from submitting the report.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -90,6 +90,6 @@ If you have any questions, concerns, or would love to suggest and give feedback 
 
 We have taken influence from the following Codes of Conduct:
 
-* The Citizen Code of Conduct is distributed by [Stumptown Syndicate](http://stumptownsyndicate.org) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/).
+* The Citizen Code of Conduct distributed by [Stumptown Syndicate](http://stumptownsyndicate.org) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/).
 
 * Portions of text derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,22 +1,29 @@
 # Citizen Code of Conduct
 
-## 1. Purpose
+## In Short
 
-A primary goal of Runway is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).
+Our Code of Conduct (CoC) at Runway aims to ensure we create an inclusive and diverse community. We aim to create a harrassment-free community. As a result, we promote:
+
+* Kindness
+* Equality
+* Respect
+
+This code of conduct applies to both online platforms and in-person experiences.
+
+If you find you are a victim, or witness any form of harrassment, either alert a Runyway Organiser immediately, or please use our [reporting tool to report the incident](https://docs.google.com/forms/d/e/1FAIpQLSeFaYn-dBkCJ9hRcrCktw1XfqgE8Gf5fu6XnK9FUBIV36iBnQ/viewform).
+
+
+## In Detail
+
+### 1. Purpose
+
+Our primary goal at Runway is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).
 
 This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
 
 We invite all those who participate in Runway to help us create safe and positive experiences for everyone.
 
-## 2. Open [Source/Culture/Tech] Citizenship
-
-A supplemental goal of this Code of Conduct is to increase open [source/culture/tech] citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
-
-Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
-
-If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
-
-## 3. Expected Behavior
+### 2. Expected Behavior
 
 The following behaviors are expected and requested of all community members:
 
@@ -27,7 +34,7 @@ The following behaviors are expected and requested of all community members:
  * Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
  * Remember that community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
 
-## 4. Unacceptable Behavior
+### 3. Unacceptable Behavior
 
 The following behaviors are considered harassment and are unacceptable within our community:
 
@@ -43,51 +50,46 @@ The following behaviors are considered harassment and are unacceptable within ou
  * Advocating for, or encouraging, any of the above behavior.
  * Sustained disruption of community events, including talks and presentations.
 
-## 5. Weapons Policy
+### 4. Weapons Policy
 
 No weapons will be allowed at Runway events, community spaces, or in other spaces covered by the scope of this Code of Conduct. Weapons include but are not limited to guns, explosives (including fireworks), and large knives such as those used for hunting or display, as well as any other item used for the purpose of causing injury or harm to others. Anyone seen in possession of one of these items will be asked to leave immediately, and will only be allowed to return without the weapon. Community members are further expected to comply with all state and local laws on this matter.
 
-## 6. Consequences of Unacceptable Behavior
+### 5. Reporting an Incident
 
-Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+If you are at an event and experience any unacceptable please do reach out to Runway staff as soon as possible. We will handle any form of unacceptable behavior as soon as it comes to our attention.
 
-Anyone asked to stop unacceptable behavior is expected to comply immediately.
-
-If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event).
-
-## 7. Reporting Guidelines
-
-If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. hello@runwayml.com.
-
-
+If you are subject to or witness unacceptable behavior and want to raise an incident report, please do use our [reporting tool to report the incident](https://docs.google.com/forms/d/e/1FAIpQLSeFaYn-dBkCJ9hRcrCktw1XfqgE8Gf5fu6XnK9FUBIV36iBnQ/viewform) as soon as you can. If you choose to raise an incident report, we will ensure we investigate and provide followup within 2 weeks of the report. Your information will remain confidential from submitting the report.
 
 Additionally, community organizers are available to help community members engage with local law enforcement or to otherwise help those experiencing unacceptable behavior feel safe. In the context of in-person events, organizers will also provide escorts as desired by the person experiencing distress.
 
-## 8. Addressing Grievances
+### 6. Conflict Resolution
 
-If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify Runway AI, Inc. with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies. 
+Unacceptable behavior from any community member, including sponsors/employees will not be tolerated. Anyone asked to stop unacceptable behavior is expected to comply immediately.
 
+If you have used our reporting tool, to report an incident and breach of our CoC, we will begin an internal investigation of the incident. This may involve follow-up talks to ensure we have as much information as possible to ensure we take appropriate action. We aim to respond within two weeks of submitting an incident report.
 
-## 9. Scope
+If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event).
 
-We expect all community participants (contributors, paid or otherwise; sponsors; and other guests) to abide by this Code of Conduct in all community venues--online and in-person--as well as in all one-on-one communications pertaining to community business.
+### 7. Addressing Grievances
+
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify Runway with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies.
+
+We reserve the right to reject any grievance and report which we believe to be made in bad faith.
+
+### 8. Scope
+
+We expect all community participants (contributors/sponsors/other) to abide by this Code of Conduct in any community participation - online and in-person.
 
 This code of conduct and its related procedures also applies to unacceptable behavior occurring outside the scope of community activities when such behavior has the potential to adversely affect the safety and well-being of community members.
 
-## 10. Contact info
+### 9. Contact info
 
-hello@runwayml.com
+If you have any questions, concerns, or would love to suggest and give feedback of this, please reach out to [hello@runwayml.com](mailto:hello@runwayml.com)
 
-## 11. License and attribution
+### 10. License and attribution
 
-The Citizen Code of Conduct is distributed by [Stumptown Syndicate](http://stumptownsyndicate.org) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/). 
+We have taken influence from the following Codes of Conduct:
 
-Portions of text derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
+* The Citizen Code of Conduct is distributed by [Stumptown Syndicate](http://stumptownsyndicate.org) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/).
 
-_Revision 2.3. Posted 6 March 2017._
-
-_Revision 2.2. Posted 4 February 2016._
-
-_Revision 2.1. Posted 23 June 2014._
-
-_Revision 2.0, adopted by the [Stumptown Syndicate](http://stumptownsyndicate.org) board on 10 January 2013. Posted 17 March 2013._
+* Portions of text derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).


### PR DESCRIPTION
Main changes:

- Adding a short version, vrs long.
- Integration of reporting tool
- removed the OS citizenship section - felt it was less relevant and also thinking about the wider community, beyond dev's. Potentially add something in more generic and inclusive

Next Steps:

- Should add this to website: could also keep within SDK. Important we get the wider community to follow these standards, incl. those not using github. 
- Incident tool: needs to be made as a public link
- Emails: ensure consistent emails - hello@ or team@