### PR TITLE
Use PNG as default serialization format for images

### DIFF
--- a/runway/data_types.py
+++ b/runway/data_types.py
@@ -202,8 +202,8 @@ class image(BaseType):
         else:
             raise InvalidArgumentError(self.name or self.type, 'value is not a PIL or numpy image')
         buffer = IO()
-        im_pil.save(buffer, format='JPEG')
-        return 'data:image/jpeg;base64,' + base64.b64encode(buffer.getvalue()).decode('utf8')
+        im_pil.save(buffer, format='PNG')
+        return 'data:image/png;base64,' + base64.b64encode(buffer.getvalue()).decode('utf8')
 
     def to_dict(self):
         ret = super(image, self).to_dict()


### PR DESCRIPTION
We want to eventually support specifying the output format for each key for the output, but for the time being, PNG makes more sense as the default serialization format for images. There are many cases where lossless outputs w/o color degradation are needed, as well as use cases for alpha channel transparency, for which JPEG is a poor fit.