### PR TITLE
Fix doc builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,4 +8,5 @@ formats: all
 python:
   version: 3.7
   install:
+    - requirements: requirements.txt
     - requirements: requirements-docs.txt


### PR DESCRIPTION
Recent versions of the docs site has been quietly failing to render the sphinx inline documentation. This should fix that.