### PR TITLE
Add Example Models page

### DIFF
--- a/docs/source/example_models.md
+++ b/docs/source/example_models.md
@@ -1,0 +1,10 @@
+# Example Models
+
+In order to better understand the process of porting a model to Runway, we recommend checking out the source code for some of the models that have already been ported. All models published by the runway organization are open source, as well as many of the models contributed by our community.
+
+* [Image-Super-Resolution](https://github.com/agermanidis/image-super-resolution): A very simple image upscaling model that gives a good overview of the role of [`runway_model.py`](https://github.com/agermanidis/image-super-resolution/blob/master/runway_model.py).
+* [StyleGAN](https://github.com/agermanidis/stylegan): A good example of loading a model checkpoint as well as using the [vector data type](ui_components.html#vector).
+* [SPADE-COCO](https://github.com/agermanidis/spade-coco): A good example of the [segmentation data type](ui_components.html#segmentation).
+* [DeepLabV3](https://github.com/agermanidis/DeepLabV3): A good example of multiple `@command()` functions and [conditional build steps](https://github.com/agermanidis/DeepLabV3/blob/master/runway.yml) depending on GPU and CPU build environments. Also a very simple model to get started with.
+* [Places365](https://github.com/maybay21/model_places365): A good example of a basic image classification task and use of [the text data type](ui_components.html#text) for output.
+* [3DDFA](https://github.com/maybay21/3DDFA): A good example of dealing with 3D data as images. We plan to add more features for handling true 3D data.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -92,7 +92,7 @@ build_steps:
     - pip install -r requirements.txt
 ```
 
-Continue on to the [Runway YAML reference page](runway_yaml_file.html) to learn more about the possible configuration values supported by the `runway.yml` file.
+Continue on to the [Runway YAML reference page](runway_yaml_file.html) to learn more about the possible configuration values supported by the `runway.yml` file, or hop over to the [Example Models](example_models.html) page to check out the source code for some of the models that have already been ported to Runway.
 
 <!-- http://www.sphinx-doc.org/en/1.5/markup/toctree.html -->
 ```eval_rst
@@ -107,5 +107,6 @@ Continue on to the [Runway YAML reference page](runway_yaml_file.html) to learn 
     Data Types <data_types>
     Exceptions <exceptions>
     UI Components <ui_components>
+    Example Models <example_models>
     CHANGELOG <https://github.com/runwayml/model-sdk/blob/master/CHANGELOG.md>
 ```


### PR DESCRIPTION
We can (and should!) add to this over time. Right now I selected the models that are using the most up-to-date version of the SDK so as to provide a good example use of code. I'd love to include some image models as well like GPT-2, im2txt, or AttnGAN, but it looks like all of those are using fairly outdated versions of the SDK. Perhaps when we do a model audit and bring them up to date we can include them here.

These are very few examples, but it's better than nothing!