### PR TITLE
Fix inline doc generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ clean-coverage:
 	rm -rf htmlcov
 
 docs:
-	$(MAKE) -C docs html
+	GENERATE_DOCS=1 $(MAKE) -C docs html
 
 publish-release: clean-package
 	python setup.py tag_release

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask>=0.12.2
 Flask-Cors>=3.0.2
+Flask-Compress>=1.3.1
 numpy>=1.15.0
 Pillow>=4.3.0
 gevent>=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=0.12.2
+Flask==0.12.2
 Flask-Cors>=3.0.2
 Flask-Compress>=1.3.1
 numpy>=1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==0.12.2
+Flask>=0.12.2
 Flask-Cors>=3.0.2
 Flask-Compress>=1.3.1
 numpy>=1.15.0


### PR DESCRIPTION
I noticed the inline docs + examples for https://sdk.runwayml.com have been broken for some time, so I decided to spend a bit of time investigating them in the spirit of this week's Runway Hack Days.

Two issues were causing the doc generation process to fail:

* Flask-Compress was being imported, but not defined in `requirements.txt`
* An error importing `from scipy.spatial.distance import cdist` during doc generation

It's unclear to my why these two issues would effect doc generation only, and not also cause issues for the `runway-python` module itself. 

Another thing I was surprised by was that if you `pip install -r requirements.txt` and then `pip freeze | grep Flask` I see that Flask 1.x.x is installed, even though we specify `Flask>=0.12.2` in `requirements.txt`. Does that mean we're operating Flask 1.x for some of our more recently built models?